### PR TITLE
Add offline todo app

### DIFF
--- a/todo-app/app.js
+++ b/todo-app/app.js
@@ -1,0 +1,662 @@
+(() => {
+  const STORAGE_KEY = 'todo.v1';
+  const VERSION = 1;
+  const DEFAULT_STATE = {
+    version: VERSION,
+    prefs: {
+      theme: 'dark',
+      bgImageDataUrl: '',
+      filter: 'all',
+      lastUndo: null,
+      lastLongtermReset: null
+    },
+    items: []
+  };
+
+  const sections = ['inProgress', 'done', 'longterm', 'trash'];
+  const sectionLabels = {
+    inProgress: '进行中',
+    done: '已完成',
+    longterm: '长期',
+    trash: '垃圾桶'
+  };
+
+  const Store = {
+    load() {
+      try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return structuredClone(DEFAULT_STATE);
+        const data = JSON.parse(raw);
+        return this.migrate(data);
+      } catch (err) {
+        console.warn('读取存储失败，已重置。', err);
+        return structuredClone(DEFAULT_STATE);
+      }
+    },
+    save(state) {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+      } catch (err) {
+        console.error('保存失败', err);
+      }
+    },
+    migrate(data) {
+      if (!data || typeof data !== 'object') {
+        return structuredClone(DEFAULT_STATE);
+      }
+      if (!data.version || data.version < VERSION) {
+        data.version = VERSION;
+      }
+      if (!data.prefs) {
+        data.prefs = structuredClone(DEFAULT_STATE.prefs);
+      } else {
+        data.prefs = { ...structuredClone(DEFAULT_STATE.prefs), ...data.prefs };
+      }
+      if (!Array.isArray(data.items)) {
+        data.items = [];
+      }
+      data.items = data.items.map((item) => ({
+        doneToday: false,
+        ...item
+      }));
+      return data;
+    }
+  };
+
+  const dom = {
+    undoBtn: document.getElementById('undoBtn'),
+    filterButtons: Array.from(document.querySelectorAll('.filter-btn')),
+    themeToggle: document.getElementById('themeToggle'),
+    exportBtn: document.getElementById('exportBtn'),
+    importBtn: document.getElementById('importBtn'),
+    themeFileInput: document.getElementById('themeFileInput'),
+    importFileInput: document.getElementById('importFileInput'),
+    searchInput: document.getElementById('searchInput'),
+    newTodoForm: document.getElementById('newTodoForm'),
+    newTodoInput: document.getElementById('newTodoInput'),
+    addToLongterm: document.getElementById('addToLongterm'),
+    clearTrashBtn: document.getElementById('clearTrashBtn'),
+    lists: {
+      inProgress: document.getElementById('inProgressList'),
+      done: document.getElementById('doneList'),
+      longterm: document.getElementById('longtermList'),
+      trash: document.getElementById('trashList')
+    },
+    counts: {
+      inProgress: document.getElementById('inProgressCount'),
+      done: document.getElementById('doneCount'),
+      longterm: document.getElementById('longtermCount'),
+      trash: document.getElementById('trashCount')
+    },
+    columns: {
+      inProgress: document.querySelector('section[data-section="inProgress"]'),
+      done: document.querySelector('section[data-section="done"]'),
+      longterm: document.querySelector('section[data-section="longterm"]'),
+      trash: document.querySelector('section[data-section="trash"]')
+    },
+    toggleControl: document.querySelector('#newTodoForm .toggle')
+  };
+
+  let state = Store.load();
+  let searchTerm = '';
+
+  function structuredClone(obj) {
+    return JSON.parse(JSON.stringify(obj));
+  }
+
+  function formatDate(ts) {
+    if (!ts) return '';
+    const date = new Date(ts);
+    const options = { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' };
+    return new Intl.DateTimeFormat('zh-CN', options).format(date);
+  }
+
+  function getTodayKey() {
+    const now = new Date();
+    const y = now.getFullYear();
+    const m = String(now.getMonth() + 1).padStart(2, '0');
+    const d = String(now.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+  }
+
+  function generateId() {
+    return `todo-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+  }
+
+  function mutate(updater, { skipRender = false } = {}) {
+    updater(state);
+    Store.save(state);
+    if (!skipRender) {
+      render();
+    }
+  }
+
+  function resetLongtermDailyIfNeeded() {
+    const today = getTodayKey();
+    if (state.prefs.lastLongtermReset === today) {
+      return;
+    }
+    state.items.forEach((item) => {
+      if (item.section === 'longterm' && item.doneToday) {
+        item.doneToday = false;
+      }
+    });
+    state.prefs.lastLongtermReset = today;
+    Store.save(state);
+  }
+
+  function applyTheme() {
+    const theme = state.prefs.theme || 'dark';
+    document.body.dataset.theme = theme;
+    if (theme === 'image' && state.prefs.bgImageDataUrl) {
+      document.body.style.setProperty('--custom-bg', `url(${state.prefs.bgImageDataUrl})`);
+    } else {
+      document.body.style.removeProperty('--custom-bg');
+    }
+    const themeButtonLabel = theme === 'image' ? '恢复暗夜' : '自定义背景';
+    dom.themeToggle.textContent = themeButtonLabel;
+    dom.themeToggle.title = theme === 'image' ? '恢复暗夜背景' : '选择自定义背景图片';
+    dom.themeToggle.setAttribute('aria-label', theme === 'image' ? '恢复暗夜背景' : '选择自定义背景图片');
+  }
+
+  function updateUndoButton() {
+    dom.undoBtn.disabled = !state.prefs.lastUndo;
+  }
+
+  function getItemsBySection(section) {
+    return state.items
+      .filter((item) => item.section === section)
+      .sort((a, b) => a.createdAt - b.createdAt);
+  }
+
+  function render() {
+    applyTheme();
+    updateUndoButton();
+    updateFilterButtons();
+    sections.forEach((section) => renderSection(section));
+  }
+
+  function updateFilterButtons() {
+    dom.filterButtons.forEach((btn) => {
+      const active = btn.dataset.filter === state.prefs.filter;
+      btn.classList.toggle('active', active);
+      btn.setAttribute('aria-checked', active ? 'true' : 'false');
+    });
+    const mainSections = ['inProgress', 'done', 'longterm'];
+    mainSections.forEach((section) => {
+      const column = dom.columns[section];
+      if (!column) return;
+      if (state.prefs.filter === 'all' || state.prefs.filter === section) {
+        column.classList.remove('hidden');
+      } else {
+        column.classList.add('hidden');
+      }
+    });
+  }
+
+  function renderSection(section) {
+    const list = dom.lists[section];
+    const column = dom.columns[section];
+    if (!list || !column) return;
+    const items = getItemsBySection(section);
+    const filteredItems = items.filter((item) => {
+      if (!searchTerm) return true;
+      return item.text.toLowerCase().includes(searchTerm.toLowerCase());
+    });
+
+    list.innerHTML = '';
+    filteredItems.forEach((item) => {
+      const element = createItemElement(item);
+      list.appendChild(element);
+    });
+
+    const count = items.length;
+    dom.counts[section].textContent = count;
+    if (section === 'trash') {
+      dom.clearTrashBtn.disabled = count === 0;
+    }
+    if (filteredItems.length === 0) {
+      column.classList.add('show-empty');
+    } else {
+      column.classList.remove('show-empty');
+    }
+  }
+
+  function createItemElement(item) {
+    const template = document.getElementById('todoItemTemplate');
+    const clone = template.content.firstElementChild.cloneNode(true);
+    clone.dataset.id = item.id;
+    clone.dataset.section = item.section;
+    clone.classList.toggle('done', item.section === 'done');
+    clone.classList.toggle('longterm', item.section === 'longterm');
+    clone.classList.toggle('trash', item.section === 'trash');
+    clone.classList.toggle('done-today', !!item.doneToday);
+
+    const checkbox = clone.querySelector('input[type="checkbox"]');
+    const content = clone.querySelector('.item-content');
+    const meta = clone.querySelector('.item-meta');
+    const deleteBtn = clone.querySelector('.delete-btn');
+    const restoreBtn = clone.querySelector('.restore-btn');
+    const longtermStatus = clone.querySelector('.longterm-status');
+
+    content.textContent = item.text;
+
+    if (item.section === 'inProgress') {
+      checkbox.checked = false;
+      checkbox.setAttribute('aria-label', '标记为完成');
+    } else if (item.section === 'done') {
+      checkbox.checked = true;
+      checkbox.setAttribute('aria-label', '还原为进行中');
+    } else if (item.section === 'longterm') {
+      checkbox.checked = !!item.doneToday;
+      checkbox.setAttribute('aria-label', '标记今日已完成');
+      longtermStatus.textContent = item.doneToday ? '今日已打卡' : '';
+    }
+
+    if (item.section === 'trash') {
+      clone.setAttribute('aria-label', `${item.text}，位于垃圾桶`);
+    } else {
+      clone.setAttribute('aria-label', `${item.text}`);
+    }
+
+    const metaParts = [];
+    if (item.section === 'trash' && item.trashedFrom) {
+      metaParts.push(`来自：${sectionLabels[item.trashedFrom] || '未知'}`);
+    }
+    if (item.section !== 'trash') {
+      metaParts.push(`创建：${formatDate(item.createdAt)}`);
+    } else {
+      metaParts.push(`创建：${formatDate(item.createdAt)}`);
+    }
+    if (item.updatedAt && item.updatedAt !== item.createdAt) {
+      metaParts.push(`更新：${formatDate(item.updatedAt)}`);
+    }
+    meta.textContent = metaParts.join(' · ');
+
+    if (item.section === 'trash') {
+      deleteBtn.innerHTML = '';
+      deleteBtn.classList.add('danger');
+      deleteBtn.appendChild(createIconImg('assets/icon-trash.svg'));
+      deleteBtn.appendChild(document.createTextNode('彻底删除'));
+      checkbox.disabled = true;
+      restoreBtn.hidden = false;
+      restoreBtn.innerHTML = '';
+      restoreBtn.appendChild(createIconImg('assets/icon-restore.svg'));
+      restoreBtn.appendChild(document.createTextNode('还原'));
+    } else {
+      restoreBtn.hidden = true;
+      deleteBtn.classList.remove('danger');
+    }
+
+    checkbox.disabled = item.section === 'trash';
+    checkbox.addEventListener('change', () => handleCheckboxChange(item));
+    deleteBtn.addEventListener('click', (event) => {
+      event.stopPropagation();
+      if (item.section === 'trash') {
+        handlePermanentDelete(item.id);
+      } else {
+        handleDelete(item.id);
+      }
+    });
+
+    if (restoreBtn) {
+      restoreBtn.addEventListener('click', (event) => {
+        event.stopPropagation();
+        handleRestore(item.id);
+      });
+    }
+
+    if (item.section !== 'trash') {
+      content.addEventListener('dblclick', () => {
+        startEditing(clone, item);
+      });
+    }
+
+    clone.addEventListener('keydown', (event) => {
+      if ((event.key === 'Enter' || event.key === ' ') && document.activeElement === clone) {
+        event.preventDefault();
+        const check = clone.querySelector('input[type="checkbox"]');
+        if (check && !check.disabled) {
+          check.click();
+        }
+      }
+    });
+
+    return clone;
+  }
+
+  function createIconImg(src, altText = '') {
+    const img = document.createElement('img');
+    img.src = src;
+    img.alt = altText;
+    img.setAttribute('aria-hidden', 'true');
+    return img;
+  }
+
+  function startEditing(element, item) {
+    if (element.classList.contains('editing')) return;
+    element.classList.add('editing');
+    const content = element.querySelector('.item-content');
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.value = item.text;
+    input.className = 'edit-input';
+    input.setAttribute('aria-label', '编辑待办');
+    element.insertBefore(input, content);
+    input.focus();
+    input.select();
+
+    const cancelEdit = () => {
+      element.classList.remove('editing');
+      input.remove();
+    };
+
+    input.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        const nextValue = input.value.trim();
+        if (!nextValue) {
+          alert('内容不能为空。');
+          return;
+        }
+        mutate((draft) => {
+          const target = draft.items.find((it) => it.id === item.id);
+          if (target) {
+            target.text = nextValue;
+            target.updatedAt = Date.now();
+          }
+        });
+        cancelEdit();
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        cancelEdit();
+      }
+    });
+
+    input.addEventListener('blur', () => {
+      cancelEdit();
+    });
+  }
+
+  function handleCheckboxChange(item) {
+    if (item.section === 'inProgress') {
+      mutate((draft) => {
+        const target = draft.items.find((it) => it.id === item.id);
+        if (target) {
+          target.section = 'done';
+          target.updatedAt = Date.now();
+        }
+      });
+    } else if (item.section === 'done') {
+      mutate((draft) => {
+        const target = draft.items.find((it) => it.id === item.id);
+        if (target) {
+          target.section = 'inProgress';
+          target.updatedAt = Date.now();
+        }
+      });
+    } else if (item.section === 'longterm') {
+      mutate((draft) => {
+        const target = draft.items.find((it) => it.id === item.id);
+        if (target) {
+          target.doneToday = !target.doneToday;
+          target.updatedAt = Date.now();
+        }
+      });
+    }
+  }
+
+  function handleDelete(id) {
+    const confirmed = window.confirm('确认要删除此条目并移至垃圾桶吗？');
+    if (!confirmed) return;
+    mutate((draft) => {
+      const target = draft.items.find((item) => item.id === id);
+      if (!target || target.section === 'trash') return;
+      const fromSection = target.section;
+      target.trashedFrom = fromSection;
+      target.section = 'trash';
+      target.doneToday = false;
+      target.updatedAt = Date.now();
+      draft.prefs.lastUndo = { itemId: target.id, from: fromSection };
+    });
+  }
+
+  function handlePermanentDelete(id) {
+    const confirmed = window.confirm('确认要彻底删除此条目吗？该操作不可撤销。');
+    if (!confirmed) return;
+    mutate((draft) => {
+      draft.items = draft.items.filter((item) => item.id !== id);
+      if (draft.prefs.lastUndo && draft.prefs.lastUndo.itemId === id) {
+        draft.prefs.lastUndo = null;
+      }
+    });
+  }
+
+  function handleRestore(id) {
+    mutate((draft) => {
+      const target = draft.items.find((item) => item.id === id);
+      if (!target || target.section !== 'trash') return;
+      const toSection = target.trashedFrom || 'inProgress';
+      target.section = toSection;
+      target.updatedAt = Date.now();
+      if (draft.prefs.lastUndo && draft.prefs.lastUndo.itemId === id) {
+        draft.prefs.lastUndo = null;
+      }
+    });
+  }
+
+  function handleUndo() {
+    const undo = state.prefs.lastUndo;
+    if (!undo) return;
+    mutate((draft) => {
+      const target = draft.items.find((item) => item.id === undo.itemId);
+      if (!target || target.section !== 'trash') {
+        draft.prefs.lastUndo = null;
+        return;
+      }
+      target.section = undo.from || 'inProgress';
+      target.updatedAt = Date.now();
+      draft.prefs.lastUndo = null;
+    });
+  }
+
+  function handleClearTrash() {
+    if (!state.items.some((item) => item.section === 'trash')) return;
+    const confirmed = window.confirm('确认要清空垃圾桶吗？此操作不可恢复。');
+    if (!confirmed) return;
+    mutate((draft) => {
+      draft.items = draft.items.filter((item) => item.section !== 'trash');
+      draft.prefs.lastUndo = null;
+    });
+  }
+
+  function addTodo(text, toLongterm) {
+    const trimmed = text.trim();
+    if (!trimmed) {
+      alert('请输入内容。');
+      return;
+    }
+    mutate((draft) => {
+      const now = Date.now();
+      draft.items.push({
+        id: generateId(),
+        text: trimmed,
+        section: toLongterm ? 'longterm' : 'inProgress',
+        createdAt: now,
+        updatedAt: now,
+        doneToday: false
+      });
+    });
+  }
+
+  function updateFilter(filter) {
+    mutate((draft) => {
+      draft.prefs.filter = filter;
+    });
+  }
+
+  function updateSearch(term) {
+    searchTerm = term;
+    render();
+  }
+
+  function exportData() {
+    const blob = new Blob([JSON.stringify(state, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `todo-export-${getTodayKey()}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function importFromText(text) {
+    if (!text) return;
+    let parsed;
+    try {
+      parsed = JSON.parse(text);
+    } catch (err) {
+      alert('JSON 格式错误，请检查。');
+      return;
+    }
+    const confirmed = window.confirm('确定导入并覆盖当前数据吗？');
+    if (!confirmed) return;
+    const migrated = Store.migrate(parsed);
+    state = migrated;
+    Store.save(state);
+    resetLongtermDailyIfNeeded();
+    render();
+  }
+
+  function handleImport() {
+    const useFile = window.confirm('确定从本地文件导入吗？取消则粘贴 JSON 文本。');
+    if (useFile) {
+      dom.importFileInput.click();
+    } else {
+      const text = window.prompt('请粘贴 JSON 数据，这将覆盖现有内容：');
+      if (text && text.trim()) {
+        importFromText(text.trim());
+      }
+    }
+  }
+
+  function handleThemeToggle() {
+    if (state.prefs.theme === 'dark') {
+      dom.themeFileInput.click();
+    } else {
+      const confirmed = window.confirm('恢复暗夜主题？');
+      if (!confirmed) return;
+      mutate((draft) => {
+        draft.prefs.theme = 'dark';
+        draft.prefs.bgImageDataUrl = '';
+      });
+    }
+  }
+
+  function handleThemeFileChange(event) {
+    const file = event.target.files && event.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = reader.result;
+      mutate((draft) => {
+        draft.prefs.bgImageDataUrl = dataUrl;
+        draft.prefs.theme = 'image';
+      });
+      dom.themeFileInput.value = '';
+    };
+    reader.readAsDataURL(file);
+  }
+
+  function handleImportFileChange(event) {
+    const file = event.target.files && event.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      importFromText(reader.result);
+      dom.importFileInput.value = '';
+    };
+    reader.readAsText(file, 'utf-8');
+  }
+
+  function setupEvents() {
+    const syncToggleSwitch = () => {
+      if (dom.toggleControl) {
+        dom.toggleControl.setAttribute('aria-checked', dom.addToLongterm.checked ? 'true' : 'false');
+      }
+    };
+
+    if (dom.toggleControl) {
+      dom.toggleControl.addEventListener('keydown', (event) => {
+        if (event.key === ' ' || event.key === 'Enter') {
+          event.preventDefault();
+          dom.addToLongterm.checked = !dom.addToLongterm.checked;
+          syncToggleSwitch();
+        }
+      });
+      dom.addToLongterm.addEventListener('change', syncToggleSwitch);
+      syncToggleSwitch();
+    }
+
+    dom.newTodoForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      addTodo(dom.newTodoInput.value, dom.addToLongterm.checked);
+      dom.newTodoInput.value = '';
+      dom.addToLongterm.checked = false;
+      syncToggleSwitch();
+      dom.newTodoInput.focus();
+    });
+
+    dom.filterButtons.forEach((btn) => {
+      btn.addEventListener('click', () => {
+        updateFilter(btn.dataset.filter);
+      });
+    });
+
+    dom.undoBtn.addEventListener('click', handleUndo);
+    dom.clearTrashBtn.addEventListener('click', handleClearTrash);
+    dom.exportBtn.addEventListener('click', exportData);
+    dom.importBtn.addEventListener('click', handleImport);
+    dom.themeToggle.addEventListener('click', handleThemeToggle);
+    dom.themeFileInput.addEventListener('change', handleThemeFileChange);
+    dom.importFileInput.addEventListener('change', handleImportFileChange);
+
+    dom.searchInput.addEventListener('input', (event) => {
+      updateSearch(event.target.value);
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
+        return;
+      }
+      if (event.key === 'n' || event.key === 'N') {
+        event.preventDefault();
+        dom.newTodoInput.focus();
+      } else if (event.key === '/') {
+        event.preventDefault();
+        dom.searchInput.focus();
+      } else if (event.key === 'Delete') {
+        const active = document.activeElement;
+        const itemEl = active && active.closest && active.closest('.todo-item');
+        if (itemEl) {
+          const id = itemEl.dataset.id;
+          const section = itemEl.dataset.section;
+          if (section !== 'trash') {
+            handleDelete(id);
+          }
+        }
+      } else if (event.key === 'z' && (event.ctrlKey || event.metaKey)) {
+        event.preventDefault();
+        handleUndo();
+      }
+    });
+
+    dom.searchInput.addEventListener('focus', () => {
+      dom.searchInput.select();
+    });
+  }
+
+  resetLongtermDailyIfNeeded();
+  setupEvents();
+  render();
+})();

--- a/todo-app/assets/icon-add.svg
+++ b/todo-app/assets/icon-add.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10" stroke="white" fill="rgba(255,255,255,0.1)" />
+  <line x1="12" y1="7" x2="12" y2="17" />
+  <line x1="7" y1="12" x2="17" y2="12" />
+</svg>

--- a/todo-app/assets/icon-restore.svg
+++ b/todo-app/assets/icon-restore.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 4v6h6" />
+  <path d="M20 11c-1-5-5.5-8-10-7-3.6.8-6.3 4-6 7.7.4 3.8 3.7 6.8 7.5 6.8 2.7 0 5.1-1.4 6.5-3.5" />
+</svg>

--- a/todo-app/assets/icon-trash.svg
+++ b/todo-app/assets/icon-trash.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="3 6 5 6 21 6" />
+  <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+  <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+  <line x1="10" y1="11" x2="10" y2="17" />
+  <line x1="14" y1="11" x2="14" y2="17" />
+</svg>

--- a/todo-app/assets/icon-upload.svg
+++ b/todo-app/assets/icon-upload.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+  <polyline points="7 10 12 5 17 10" />
+  <line x1="12" y1="5" x2="12" y2="19" />
+</svg>

--- a/todo-app/index.html
+++ b/todo-app/index.html
@@ -1,0 +1,127 @@
+<!-- 使用说明 & 快捷键：N 新建；/ 搜索；Delete 删除；Ctrl+Z 撤销；双击条目可编辑；Enter 保存编辑；Esc 取消编辑。 -->
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>离线待办清单</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="app-header" role="banner">
+    <div class="branding" tabindex="0">
+      <h1>离线待办</h1>
+      <span class="tagline">规划 · 打卡 · 管理</span>
+    </div>
+    <div class="search-area" role="search">
+      <label class="sr-only" for="searchInput">搜索待办</label>
+      <input id="searchInput" type="search" placeholder="搜索所有待办 /" aria-label="搜索待办" />
+    </div>
+    <div class="header-actions" role="group" aria-label="快速操作">
+      <button id="undoBtn" class="ghost" aria-label="撤销上一次删除" title="撤销上一次删除 (Ctrl+Z)" disabled>
+        撤销
+      </button>
+      <div class="filter-group" role="radiogroup" aria-label="筛选视图">
+        <button class="filter-btn active" data-filter="all" role="radio" aria-checked="true">全部</button>
+        <button class="filter-btn" data-filter="inProgress" role="radio" aria-checked="false">进行中</button>
+        <button class="filter-btn" data-filter="done" role="radio" aria-checked="false">已完成</button>
+        <button class="filter-btn" data-filter="longterm" role="radio" aria-checked="false">长期</button>
+      </div>
+      <button id="themeToggle" class="ghost" aria-label="背景切换" title="背景切换">
+        背景切换
+      </button>
+      <button id="exportBtn" class="ghost" aria-label="导出待办 JSON" title="导出 JSON">
+        导出
+      </button>
+      <button id="importBtn" class="ghost" aria-label="导入待办 JSON" title="导入 JSON">
+        导入
+      </button>
+      <input id="themeFileInput" type="file" accept="image/*" hidden />
+      <input id="importFileInput" type="file" accept="application/json" hidden />
+    </div>
+  </header>
+
+  <main class="app-main" role="main">
+    <section class="column" data-section="inProgress" aria-labelledby="inProgressTitle">
+      <header class="column-header">
+        <h2 id="inProgressTitle">进行中</h2>
+        <span class="badge" id="inProgressCount">0</span>
+      </header>
+      <form id="newTodoForm" aria-label="新增待办">
+        <label class="sr-only" for="newTodoInput">新增待办</label>
+        <div class="input-group">
+          <input id="newTodoInput" type="text" placeholder="输入待办事项..." aria-label="待办内容" required />
+          <button type="submit" class="primary" aria-label="添加待办">
+            <img src="assets/icon-add.svg" alt="" aria-hidden="true" />
+            添加
+          </button>
+        </div>
+        <label class="toggle" tabindex="0" role="switch" aria-checked="false">
+          <input type="checkbox" id="addToLongterm" />
+          <span class="slider" aria-hidden="true"></span>
+          <span class="toggle-label">加入长期栏</span>
+        </label>
+      </form>
+      <div class="empty-state" data-section="inProgress">🎯 今天的目标是什么？开始添加吧。</div>
+      <ul class="todo-list" id="inProgressList" aria-label="进行中待办列表"></ul>
+    </section>
+
+    <section class="column" data-section="done" aria-labelledby="doneTitle">
+      <header class="column-header">
+        <h2 id="doneTitle">已完成</h2>
+        <span class="badge" id="doneCount">0</span>
+      </header>
+      <div class="empty-state" data-section="done">✨ 完成会带来满足感，加油！</div>
+      <ul class="todo-list" id="doneList" aria-label="已完成待办列表"></ul>
+    </section>
+
+    <section class="column" data-section="longterm" aria-labelledby="longtermTitle">
+      <header class="column-header">
+        <h2 id="longtermTitle">长期</h2>
+        <span class="badge" id="longtermCount">0</span>
+      </header>
+      <div class="empty-state" data-section="longterm">🌱 积少成多，让习惯开花。</div>
+      <ul class="todo-list" id="longtermList" aria-label="长期待办列表"></ul>
+    </section>
+
+    <section class="column" data-section="trash" aria-labelledby="trashTitle">
+      <header class="column-header">
+        <h2 id="trashTitle">垃圾桶</h2>
+        <span class="badge" id="trashCount">0</span>
+        <button id="clearTrashBtn" class="ghost" aria-label="清空垃圾桶" title="清空垃圾桶">
+          <img src="assets/icon-trash.svg" alt="" aria-hidden="true" />
+          清空
+        </button>
+      </header>
+      <div class="empty-state" data-section="trash">🗑️ 垃圾桶是空的。</div>
+      <ul class="todo-list" id="trashList" aria-label="垃圾桶列表"></ul>
+    </section>
+  </main>
+
+  <template id="todoItemTemplate">
+    <li class="todo-item" tabindex="0">
+      <div class="item-main">
+        <label class="checkbox" aria-label="标记状态">
+          <input type="checkbox" />
+          <span class="checkmark" aria-hidden="true"></span>
+        </label>
+        <div class="item-content" role="textbox" aria-readonly="true"></div>
+        <span class="longterm-status" aria-hidden="true"></span>
+      </div>
+      <div class="item-meta"></div>
+      <div class="item-actions">
+        <button class="restore-btn ghost" aria-label="还原到原分区" title="还原">
+          <img src="assets/icon-restore.svg" alt="" aria-hidden="true" />
+        </button>
+        <button class="delete-btn ghost" aria-label="删除" title="删除">
+          <img src="assets/icon-trash.svg" alt="" aria-hidden="true" />
+        </button>
+      </div>
+    </li>
+  </template>
+
+  <textarea id="importTextarea" class="modal-textarea" aria-label="导入 JSON 输入框" hidden></textarea>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/todo-app/styles.css
+++ b/todo-app/styles.css
@@ -1,0 +1,500 @@
+:root {
+  --bg-gradient: radial-gradient(circle at top left, #1f2a44, #0b0d1a 60%);
+  --card-bg: rgba(21, 26, 41, 0.55);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-color: #f6f8ff;
+  --muted-color: rgba(246, 248, 255, 0.72);
+  --accent: #6c8cff;
+  --accent-soft: rgba(108, 140, 255, 0.14);
+  --danger: #ff6b81;
+  --success: #5ad1a4;
+  --focus-ring: 0 0 0 3px rgba(108, 140, 255, 0.45);
+  --shadow: 0 18px 35px rgba(7, 10, 20, 0.35);
+  --transition: 0.2s ease;
+  --glass-blur: blur(18px);
+  --column-gap: clamp(1rem, 2vw, 1.75rem);
+  --max-width: min(1280px, 92vw);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  font-family: "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+  background: var(--bg-gradient);
+  color: var(--text-color);
+  min-height: 100vh;
+}
+
+body {
+  position: relative;
+  overflow-x: hidden;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: inherit;
+  background-size: cover;
+  background-position: center;
+  opacity: 0.6;
+  z-index: -2;
+  transition: opacity var(--transition);
+}
+
+body[data-theme="image"]::before {
+  background-image: var(--custom-bg, none);
+  opacity: 1;
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  backdrop-filter: var(--glass-blur);
+  z-index: -1;
+}
+
+main, header, section, ul {
+  width: 100%;
+}
+
+.app-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.5rem;
+  margin: 0 auto;
+  width: var(--max-width);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 20px;
+  box-shadow: var(--shadow);
+  position: sticky;
+  top: 1rem;
+  z-index: 10;
+}
+
+.branding {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.branding h1 {
+  font-size: clamp(1.4rem, 2vw, 1.9rem);
+  margin: 0;
+}
+
+.tagline {
+  font-size: 0.85rem;
+  color: var(--muted-color);
+}
+
+.search-area input,
+#newTodoInput,
+.todo-item input[type="text"],
+.modal-textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-color);
+  font-size: 0.95rem;
+  transition: border var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.search-area input::placeholder,
+#newTodoInput::placeholder {
+  color: rgba(246, 248, 255, 0.5);
+}
+
+.search-area input:focus,
+#newTodoInput:focus,
+.todo-item input[type="text"]:focus,
+.modal-textarea:focus {
+  outline: none;
+  border-color: rgba(108, 140, 255, 0.45);
+  box-shadow: var(--focus-ring);
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.filter-group {
+  display: flex;
+  gap: 0.35rem;
+  background: rgba(255, 255, 255, 0.04);
+  padding: 0.35rem;
+  border-radius: 14px;
+}
+
+button {
+  border: none;
+  padding: 0.55rem 0.95rem;
+  border-radius: 12px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-color);
+  background: var(--accent-soft);
+  transition: transform var(--transition), background var(--transition), color var(--transition), box-shadow var(--transition);
+}
+
+button:focus-visible,
+.todo-item:focus-visible,
+.toggle:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+button:hover {
+  transform: translateY(-1px);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+button img {
+  width: 1rem;
+  height: 1rem;
+  margin-right: 0.35rem;
+  filter: invert(1);
+}
+
+button.ghost {
+  color: var(--muted-color);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+button.primary {
+  background: linear-gradient(135deg, #6c8cff, #4a68ff);
+  box-shadow: 0 12px 24px rgba(76, 104, 255, 0.35);
+}
+
+.filter-btn {
+  padding: 0.4rem 0.85rem;
+  border-radius: 10px;
+  background: transparent;
+  font-weight: 500;
+  color: var(--muted-color);
+}
+
+.filter-btn.active {
+  background: rgba(108, 140, 255, 0.2);
+  color: var(--text-color);
+}
+
+.app-main {
+  margin: 1.75rem auto 3rem;
+  width: var(--max-width);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--column-gap);
+}
+
+.column {
+  transition: max-height var(--transition), opacity var(--transition);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 20px;
+  padding: 1.2rem 1.25rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: var(--shadow);
+  min-height: 280px;
+}
+
+.column-header {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.column-header h2 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.badge {
+  background: rgba(108, 140, 255, 0.22);
+  color: var(--text-color);
+  border-radius: 999px;
+  padding: 0.15rem 0.6rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.02em;
+}
+
+.input-group {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  user-select: none;
+  margin-top: 0.75rem;
+}
+
+.toggle input {
+  display: none;
+}
+
+.toggle .slider {
+  width: 42px;
+  height: 24px;
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 999px;
+  position: relative;
+  transition: background var(--transition);
+}
+
+.toggle .slider::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 4px;
+  width: 18px;
+  height: 18px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform var(--transition);
+}
+
+.toggle input:checked + .slider {
+  background: rgba(90, 209, 164, 0.3);
+}
+
+.toggle input:checked + .slider::after {
+  transform: translateX(16px);
+}
+
+.toggle-label {
+  font-size: 0.85rem;
+  color: var(--muted-color);
+}
+
+.todo-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.todo-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 0.85rem 0.95rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  transition: transform var(--transition), background var(--transition), border var(--transition);
+}
+
+.todo-item:hover,
+.todo-item:focus-within,
+.todo-item:focus-visible {
+  background: rgba(255, 255, 255, 0.1);
+  transform: translateY(-2px);
+}
+
+.todo-item.trash {
+  border-color: rgba(255, 255, 255, 0.05);
+}
+
+.item-main {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.checkbox {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.08);
+  position: relative;
+}
+
+.checkbox input {
+  position: absolute;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  cursor: pointer;
+}
+
+.checkmark {
+  width: 100%;
+  height: 100%;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  color: var(--text-color);
+}
+
+.checkbox input:checked + .checkmark {
+  background: linear-gradient(135deg, #6c8cff, #4a68ff);
+  border-color: transparent;
+}
+
+.item-content {
+  flex: 1;
+  min-height: 1.3rem;
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+.todo-item.done .item-content {
+  text-decoration: line-through;
+  color: rgba(246, 248, 255, 0.5);
+}
+
+.todo-item.longterm.done-today .item-content {
+  text-decoration: none;
+  color: var(--text-color);
+}
+
+.todo-item .item-meta {
+  font-size: 0.75rem;
+  color: rgba(246, 248, 255, 0.5);
+}
+
+.item-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.todo-item .restore-btn {
+  display: none;
+}
+
+.todo-item.trash .restore-btn {
+  display: inline-flex;
+}
+
+.todo-item.trash .checkbox,
+.todo-item.trash .checkmark {
+  display: none;
+}
+
+.todo-item.longterm .longterm-status {
+  font-size: 0.75rem;
+  color: var(--muted-color);
+  background: rgba(90, 209, 164, 0.12);
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  display: none;
+}
+
+.todo-item.longterm.done-today .longterm-status {
+  display: inline-flex;
+  color: #3cd699;
+  background: rgba(60, 214, 153, 0.2);
+  font-weight: 600;
+}
+
+.empty-state {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 16px;
+  padding: 1.1rem;
+  text-align: center;
+  color: rgba(246, 248, 255, 0.6);
+  font-size: 0.9rem;
+  display: none;
+}
+
+.column.show-empty .empty-state {
+  display: block;
+}
+
+.todo-item input[type="text"] {
+  background: rgba(255, 255, 255, 0.14);
+  border-radius: 12px;
+}
+
+.todo-item.editing .item-content {
+  display: none;
+}
+
+.todo-item .edit-input {
+  width: 100%;
+}
+
+.modal-textarea {
+  min-height: 220px;
+  border-radius: 18px;
+  background: rgba(16, 20, 35, 0.9);
+  color: var(--text-color);
+  padding: 1.2rem;
+  resize: vertical;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 768px) {
+  .app-header {
+    position: static;
+  }
+
+  .app-main {
+    grid-template-columns: 1fr;
+  }
+
+  .column {
+    min-height: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    transition-duration: 0s !important;
+    animation-duration: 0s !important;
+  }
+}
+
+.column.hidden {
+  display: none;
+}
+
+button.danger, button.ghost.danger {
+  background: rgba(255, 107, 129, 0.18);
+  color: #ffced7;
+}


### PR DESCRIPTION
## Summary
- add a standalone offline todo experience with in-progress, done, long-term, and trash sections backed by localStorage
- implement background theme switching, search and filter controls, undo, keyboard shortcuts, and JSON import/export flows
- style the interface with a dark glassmorphism aesthetic, responsive layout, and inline SVG icons for offline use

## Testing
- node -e "new Function(require('fs').readFileSync('todo-app/app.js','utf8'))"

------
https://chatgpt.com/codex/tasks/task_e_68e68a8ec9988322b718fd2db8da2b48