### PR TITLE
Refine layout and add background cropping

### DIFF
--- a/todo-app/app.js
+++ b/todo-app/app.js
@@ -1,0 +1,990 @@
+(() => {
+  const STORAGE_KEY = 'todo.v1';
+  const VERSION = 1;
+  const DEFAULT_STATE = {
+    version: VERSION,
+    prefs: {
+      theme: 'dark',
+      bgImageDataUrl: '',
+      filter: 'all',
+      lastUndo: null,
+      lastLongtermReset: null
+    },
+    items: []
+  };
+
+  const mainSections = ['inProgress', 'done', 'longterm'];
+  const sectionLabels = {
+    inProgress: '进行中',
+    done: '已完成',
+    longterm: '长期',
+    trash: '垃圾桶'
+  };
+
+  const Store = {
+    load() {
+      try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return structuredClone(DEFAULT_STATE);
+        const data = JSON.parse(raw);
+        return this.migrate(data);
+      } catch (err) {
+        console.warn('读取存储失败，已重置。', err);
+        return structuredClone(DEFAULT_STATE);
+      }
+    },
+    save(state) {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+      } catch (err) {
+        console.error('保存失败', err);
+      }
+    },
+    migrate(data) {
+      if (!data || typeof data !== 'object') {
+        return structuredClone(DEFAULT_STATE);
+      }
+      if (!data.version || data.version < VERSION) {
+        data.version = VERSION;
+      }
+      if (!data.prefs) {
+        data.prefs = structuredClone(DEFAULT_STATE.prefs);
+      } else {
+        data.prefs = { ...structuredClone(DEFAULT_STATE.prefs), ...data.prefs };
+      }
+      if (!Array.isArray(data.items)) {
+        data.items = [];
+      }
+      data.items = data.items.map((item) => ({
+        doneToday: false,
+        ...item
+      }));
+      return data;
+    }
+  };
+
+  const dom = {
+    undoBtn: document.getElementById('undoBtn'),
+    filterButtons: Array.from(document.querySelectorAll('.filter-btn')),
+    themeToggle: document.getElementById('themeToggle'),
+    exportBtn: document.getElementById('exportBtn'),
+    importBtn: document.getElementById('importBtn'),
+    themeFileInput: document.getElementById('themeFileInput'),
+    importFileInput: document.getElementById('importFileInput'),
+    searchInput: document.getElementById('searchInput'),
+    newTodoForm: document.getElementById('newTodoForm'),
+    newTodoInput: document.getElementById('newTodoInput'),
+    addToLongterm: document.getElementById('addToLongterm'),
+    trashBtn: document.getElementById('trashBtn'),
+    trashPanel: document.getElementById('trashPanel'),
+    trashCloseBtn: document.getElementById('trashCloseBtn'),
+    trashList: document.getElementById('trashList'),
+    trashEmptyState: document.querySelector('#trashPanel .empty-state'),
+    clearTrashBtn: document.getElementById('clearTrashBtn'),
+    lists: {
+      inProgress: document.getElementById('inProgressList'),
+      done: document.getElementById('doneList'),
+      longterm: document.getElementById('longtermList')
+    },
+    counts: {
+      inProgress: document.getElementById('inProgressCount'),
+      done: document.getElementById('doneCount'),
+      longterm: document.getElementById('longtermCount'),
+      trash: document.getElementById('trashCount')
+    },
+    columns: {
+      inProgress: document.querySelector('section[data-section="inProgress"]'),
+      done: document.querySelector('section[data-section="done"]'),
+      longterm: document.querySelector('section[data-section="longterm"]')
+    },
+    toggleControl: document.querySelector('#newTodoForm .toggle'),
+    cropModal: document.getElementById('cropModal'),
+    cropStage: document.getElementById('cropStage'),
+    cropImage: document.getElementById('cropImage'),
+    cropZoom: document.getElementById('cropZoom'),
+    cropConfirmBtn: document.getElementById('cropConfirmBtn'),
+    cropCancelBtn: document.getElementById('cropCancelBtn')
+  };
+
+  let state = Store.load();
+  let searchTerm = '';
+  const cropState = {
+    img: null,
+    scale: 1,
+    minScale: 1,
+    maxScale: 3,
+    translateX: 0,
+    translateY: 0,
+    pointerId: null,
+    startX: 0,
+    startY: 0,
+    startTranslateX: 0,
+    startTranslateY: 0
+  };
+
+  function structuredClone(obj) {
+    return JSON.parse(JSON.stringify(obj));
+  }
+
+  function formatDate(ts) {
+    if (!ts) return '';
+    const date = new Date(ts);
+    const options = { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' };
+    return new Intl.DateTimeFormat('zh-CN', options).format(date);
+  }
+
+  function getTodayKey() {
+    const now = new Date();
+    const y = now.getFullYear();
+    const m = String(now.getMonth() + 1).padStart(2, '0');
+    const d = String(now.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+  }
+
+  function generateId() {
+    return `todo-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+  }
+
+  function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+  }
+
+  function mutate(updater, { skipRender = false } = {}) {
+    updater(state);
+    Store.save(state);
+    if (!skipRender) {
+      render();
+    }
+  }
+
+  function resetLongtermDailyIfNeeded() {
+    const today = getTodayKey();
+    if (state.prefs.lastLongtermReset === today) {
+      return;
+    }
+    state.items.forEach((item) => {
+      if (item.section === 'longterm' && item.doneToday) {
+        item.doneToday = false;
+      }
+    });
+    state.prefs.lastLongtermReset = today;
+    Store.save(state);
+  }
+
+  function applyTheme() {
+    const theme = state.prefs.theme || 'dark';
+    document.body.dataset.theme = theme;
+    if (theme === 'image' && state.prefs.bgImageDataUrl) {
+      document.body.style.setProperty('--custom-bg', `url(${state.prefs.bgImageDataUrl})`);
+    } else {
+      document.body.style.removeProperty('--custom-bg');
+    }
+    const themeButtonLabel = theme === 'image' ? '恢复暗夜' : '自定义背景';
+    dom.themeToggle.textContent = themeButtonLabel;
+    dom.themeToggle.title = theme === 'image' ? '恢复暗夜背景' : '选择自定义背景图片';
+    dom.themeToggle.setAttribute('aria-label', theme === 'image' ? '恢复暗夜背景' : '选择自定义背景图片');
+  }
+
+  function updateUndoButton() {
+    dom.undoBtn.disabled = !state.prefs.lastUndo;
+  }
+
+  function getItemsBySection(section) {
+    return state.items
+      .filter((item) => item.section === section)
+      .sort((a, b) => a.createdAt - b.createdAt);
+  }
+
+  function render() {
+    applyTheme();
+    updateUndoButton();
+    updateFilterButtons();
+    mainSections.forEach((section) => renderSection(section));
+    renderTrash();
+  }
+
+  function updateFilterButtons() {
+    dom.filterButtons.forEach((btn) => {
+      const active = btn.dataset.filter === state.prefs.filter;
+      btn.classList.toggle('active', active);
+      btn.setAttribute('aria-checked', active ? 'true' : 'false');
+    });
+    mainSections.forEach((section) => {
+      const column = dom.columns[section];
+      if (!column) return;
+      if (state.prefs.filter === 'all' || state.prefs.filter === section) {
+        column.classList.remove('hidden');
+      } else {
+        column.classList.add('hidden');
+      }
+    });
+  }
+
+  function renderSection(section) {
+    const list = dom.lists[section];
+    const column = dom.columns[section];
+    if (!list || !column) return;
+    const items = getItemsBySection(section);
+    const filteredItems = items.filter((item) => {
+      if (!searchTerm) return true;
+      return item.text.toLowerCase().includes(searchTerm.toLowerCase());
+    });
+
+    list.innerHTML = '';
+    filteredItems.forEach((item) => {
+      const element = createMainItemElement(item);
+      list.appendChild(element);
+    });
+
+    dom.counts[section].textContent = items.length;
+    const emptyState = column.querySelector('.empty-state');
+    if (emptyState) {
+      emptyState.style.display = filteredItems.length === 0 ? 'block' : 'none';
+    }
+    column.classList.toggle('show-empty', filteredItems.length === 0);
+  }
+
+  function renderTrash() {
+    const items = getItemsBySection('trash');
+    const filteredItems = items.filter((item) => {
+      if (!searchTerm) return true;
+      return item.text.toLowerCase().includes(searchTerm.toLowerCase());
+    });
+
+    if (dom.trashList) {
+      dom.trashList.innerHTML = '';
+      filteredItems.forEach((item) => {
+        const element = createTrashItemElement(item);
+        dom.trashList.appendChild(element);
+      });
+    }
+
+    if (dom.counts.trash) {
+      dom.counts.trash.textContent = items.length;
+    }
+    if (dom.trashEmptyState) {
+      dom.trashEmptyState.style.display = filteredItems.length === 0 ? 'block' : 'none';
+    }
+    if (dom.clearTrashBtn) {
+      dom.clearTrashBtn.disabled = items.length === 0;
+    }
+    if (dom.trashBtn) {
+      dom.trashBtn.classList.toggle('highlight', items.length > 0);
+      dom.trashBtn.setAttribute('aria-label', items.length > 0 ? `垃圾桶（${items.length}）` : '打开垃圾桶');
+      dom.trashBtn.title = items.length > 0 ? `垃圾桶（${items.length}）` : '垃圾桶';
+    }
+  }
+
+  function isTrashPanelOpen() {
+    return !!(dom.trashPanel && dom.trashPanel.classList.contains('open'));
+  }
+
+  function openTrashPanel() {
+    if (!dom.trashPanel) return;
+    dom.trashPanel.classList.add('open');
+    dom.trashPanel.setAttribute('aria-hidden', 'false');
+    renderTrash();
+    if (dom.trashCloseBtn) {
+      dom.trashCloseBtn.focus();
+    } else {
+      dom.trashPanel.focus();
+    }
+  }
+
+  function closeTrashPanel() {
+    if (!dom.trashPanel) return;
+    dom.trashPanel.classList.remove('open');
+    dom.trashPanel.setAttribute('aria-hidden', 'true');
+    if (dom.trashBtn) {
+      dom.trashBtn.focus();
+    }
+  }
+
+  function createMainItemElement(item) {
+    const template = document.getElementById('todoItemTemplate');
+    const clone = template.content.firstElementChild.cloneNode(true);
+    clone.dataset.id = item.id;
+    clone.dataset.section = item.section;
+    clone.classList.toggle('done', item.section === 'done');
+    clone.classList.toggle('longterm', item.section === 'longterm');
+    clone.classList.toggle('done-today', !!item.doneToday);
+
+    const checkbox = clone.querySelector('input[type="checkbox"]');
+    const content = clone.querySelector('.item-content');
+    const deleteBtn = clone.querySelector('.delete-btn');
+    const longtermStatus = clone.querySelector('.longterm-status');
+
+    content.textContent = item.text;
+    clone.setAttribute('aria-label', item.text);
+    clone.title = `创建：${formatDate(item.createdAt)}${
+      item.updatedAt && item.updatedAt !== item.createdAt ? `\n更新：${formatDate(item.updatedAt)}` : ''
+    }`;
+
+    if (item.section === 'inProgress') {
+      checkbox.checked = false;
+      checkbox.setAttribute('aria-label', '标记为完成');
+    } else if (item.section === 'done') {
+      checkbox.checked = true;
+      checkbox.setAttribute('aria-label', '还原为进行中');
+    } else if (item.section === 'longterm') {
+      checkbox.checked = !!item.doneToday;
+      checkbox.setAttribute('aria-label', '标记今日已完成');
+      longtermStatus.textContent = item.doneToday ? '今日已打卡' : '';
+    }
+
+    checkbox.addEventListener('change', () => handleCheckboxChange(item));
+    deleteBtn.addEventListener('click', (event) => {
+      event.stopPropagation();
+      handleDelete(item.id);
+    });
+
+    content.addEventListener('dblclick', () => {
+      startEditing(clone, item);
+    });
+
+    clone.addEventListener('keydown', (event) => {
+      if ((event.key === 'Enter' || event.key === ' ') && document.activeElement === clone) {
+        event.preventDefault();
+        const check = clone.querySelector('input[type="checkbox"]');
+        if (check && !check.disabled) {
+          check.click();
+        }
+      }
+    });
+
+    return clone;
+  }
+
+  function createTrashItemElement(item) {
+    const template = document.getElementById('trashItemTemplate');
+    const clone = template.content.firstElementChild.cloneNode(true);
+    clone.dataset.id = item.id;
+
+    const text = clone.querySelector('.trash-text');
+    const meta = clone.querySelector('.trash-meta');
+    const restoreBtn = clone.querySelector('.restore-btn');
+    const deleteBtn = clone.querySelector('.delete-btn');
+
+    text.textContent = item.text;
+    const metaParts = [];
+    if (item.trashedFrom) {
+      metaParts.push(`来自：${sectionLabels[item.trashedFrom] || '未知'}`);
+    }
+    metaParts.push(`创建：${formatDate(item.createdAt)}`);
+    if (item.updatedAt && item.updatedAt !== item.createdAt) {
+      metaParts.push(`更新：${formatDate(item.updatedAt)}`);
+    }
+    meta.textContent = metaParts.join(' · ');
+
+    restoreBtn.addEventListener('click', (event) => {
+      event.stopPropagation();
+      handleRestore(item.id);
+    });
+
+    deleteBtn.addEventListener('click', (event) => {
+      event.stopPropagation();
+      handlePermanentDelete(item.id);
+    });
+
+    clone.addEventListener('keydown', (event) => {
+      if ((event.key === 'Enter' || event.key === ' ') && document.activeElement === clone) {
+        event.preventDefault();
+        handleRestore(item.id);
+      }
+    });
+
+    return clone;
+  }
+
+  function startEditing(element, item) {
+    if (element.classList.contains('editing')) return;
+    element.classList.add('editing');
+    const body = element.querySelector('.item-body') || element;
+    const content = body.querySelector('.item-content');
+    const status = body.querySelector('.longterm-status');
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.value = item.text;
+    input.className = 'edit-input';
+    input.setAttribute('aria-label', '编辑待办');
+    if (status) {
+      status.hidden = true;
+    }
+    if (content) {
+      content.hidden = true;
+    }
+    body.insertBefore(input, content || body.firstChild);
+    input.focus();
+    input.select();
+
+    const cancelEdit = () => {
+      element.classList.remove('editing');
+      if (content) {
+        content.hidden = false;
+      }
+      if (status) {
+        status.hidden = false;
+      }
+      input.remove();
+    };
+
+    input.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        const nextValue = input.value.trim();
+        if (!nextValue) {
+          alert('内容不能为空。');
+          return;
+        }
+        mutate((draft) => {
+          const target = draft.items.find((it) => it.id === item.id);
+          if (target) {
+            target.text = nextValue;
+            target.updatedAt = Date.now();
+          }
+        });
+        cancelEdit();
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        cancelEdit();
+      }
+    });
+
+    input.addEventListener('blur', () => {
+      cancelEdit();
+    });
+  }
+
+  function handleCheckboxChange(item) {
+    if (item.section === 'inProgress') {
+      mutate((draft) => {
+        const target = draft.items.find((it) => it.id === item.id);
+        if (target) {
+          target.section = 'done';
+          target.updatedAt = Date.now();
+        }
+      });
+    } else if (item.section === 'done') {
+      mutate((draft) => {
+        const target = draft.items.find((it) => it.id === item.id);
+        if (target) {
+          target.section = 'inProgress';
+          target.updatedAt = Date.now();
+        }
+      });
+    } else if (item.section === 'longterm') {
+      mutate((draft) => {
+        const target = draft.items.find((it) => it.id === item.id);
+        if (target) {
+          target.doneToday = !target.doneToday;
+          target.updatedAt = Date.now();
+        }
+      });
+    }
+  }
+
+  function handleDelete(id) {
+    const confirmed = window.confirm('确认要删除此条目并移至垃圾桶吗？');
+    if (!confirmed) return;
+    mutate((draft) => {
+      const target = draft.items.find((item) => item.id === id);
+      if (!target || target.section === 'trash') return;
+      const fromSection = target.section;
+      target.trashedFrom = fromSection;
+      target.section = 'trash';
+      target.doneToday = false;
+      target.updatedAt = Date.now();
+      draft.prefs.lastUndo = { itemId: target.id, from: fromSection };
+    });
+  }
+
+  function handlePermanentDelete(id) {
+    const confirmed = window.confirm('确认要彻底删除此条目吗？该操作不可撤销。');
+    if (!confirmed) return;
+    mutate((draft) => {
+      draft.items = draft.items.filter((item) => item.id !== id);
+      if (draft.prefs.lastUndo && draft.prefs.lastUndo.itemId === id) {
+        draft.prefs.lastUndo = null;
+      }
+    });
+  }
+
+  function handleRestore(id) {
+    mutate((draft) => {
+      const target = draft.items.find((item) => item.id === id);
+      if (!target || target.section !== 'trash') return;
+      const toSection = target.trashedFrom || 'inProgress';
+      target.section = toSection;
+      target.updatedAt = Date.now();
+      if (draft.prefs.lastUndo && draft.prefs.lastUndo.itemId === id) {
+        draft.prefs.lastUndo = null;
+      }
+    });
+  }
+
+  function handleUndo() {
+    const undo = state.prefs.lastUndo;
+    if (!undo) return;
+    mutate((draft) => {
+      const target = draft.items.find((item) => item.id === undo.itemId);
+      if (!target || target.section !== 'trash') {
+        draft.prefs.lastUndo = null;
+        return;
+      }
+      target.section = undo.from || 'inProgress';
+      target.updatedAt = Date.now();
+      draft.prefs.lastUndo = null;
+    });
+  }
+
+  function handleClearTrash() {
+    if (!state.items.some((item) => item.section === 'trash')) return;
+    const confirmed = window.confirm('确认要清空垃圾桶吗？此操作不可恢复。');
+    if (!confirmed) return;
+    mutate((draft) => {
+      draft.items = draft.items.filter((item) => item.section !== 'trash');
+      draft.prefs.lastUndo = null;
+    });
+  }
+
+  function addTodo(text, toLongterm) {
+    const trimmed = text.trim();
+    if (!trimmed) {
+      alert('请输入内容。');
+      return;
+    }
+    mutate((draft) => {
+      const now = Date.now();
+      draft.items.push({
+        id: generateId(),
+        text: trimmed,
+        section: toLongterm ? 'longterm' : 'inProgress',
+        createdAt: now,
+        updatedAt: now,
+        doneToday: false
+      });
+    });
+  }
+
+  function updateFilter(filter) {
+    mutate((draft) => {
+      draft.prefs.filter = filter;
+    });
+  }
+
+  function updateSearch(term) {
+    searchTerm = term;
+    render();
+  }
+
+  function exportData() {
+    const blob = new Blob([JSON.stringify(state, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `todo-export-${getTodayKey()}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function importFromText(text) {
+    if (!text) return;
+    let parsed;
+    try {
+      parsed = JSON.parse(text);
+    } catch (err) {
+      alert('JSON 格式错误，请检查。');
+      return;
+    }
+    const confirmed = window.confirm('确定导入并覆盖当前数据吗？');
+    if (!confirmed) return;
+    const migrated = Store.migrate(parsed);
+    state = migrated;
+    Store.save(state);
+    resetLongtermDailyIfNeeded();
+    render();
+  }
+
+  function handleImport() {
+    const useFile = window.confirm('确定从本地文件导入吗？取消则粘贴 JSON 文本。');
+    if (useFile) {
+      dom.importFileInput.click();
+    } else {
+      const text = window.prompt('请粘贴 JSON 数据，这将覆盖现有内容：');
+      if (text && text.trim()) {
+        importFromText(text.trim());
+      }
+    }
+  }
+
+  function handleThemeToggle() {
+    if (state.prefs.theme === 'dark') {
+      dom.themeFileInput.click();
+    } else {
+      const confirmed = window.confirm('恢复暗夜主题？');
+      if (!confirmed) return;
+      mutate((draft) => {
+        draft.prefs.theme = 'dark';
+        draft.prefs.bgImageDataUrl = '';
+      });
+    }
+  }
+
+  function handleThemeFileChange(event) {
+    const file = event.target.files && event.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = reader.result;
+      if (typeof dataUrl === 'string') {
+        openCropModal(dataUrl);
+      }
+      dom.themeFileInput.value = '';
+    };
+    reader.onerror = () => {
+      alert('读取图片失败，请重试。');
+      dom.themeFileInput.value = '';
+    };
+    reader.readAsDataURL(file);
+  }
+
+  function isCropModalOpen() {
+    return !!(dom.cropModal && dom.cropModal.classList.contains('open'));
+  }
+
+  function resetCropState() {
+    cropState.img = null;
+    cropState.scale = 1;
+    cropState.minScale = 1;
+    cropState.maxScale = 3;
+    cropState.translateX = 0;
+    cropState.translateY = 0;
+    cropState.pointerId = null;
+    cropState.startX = 0;
+    cropState.startY = 0;
+    cropState.startTranslateX = 0;
+    cropState.startTranslateY = 0;
+    if (dom.cropImage) {
+      dom.cropImage.src = '';
+      dom.cropImage.style.transform = '';
+    }
+    if (dom.cropZoom) {
+      dom.cropZoom.value = '1';
+      dom.cropZoom.min = '1';
+      dom.cropZoom.max = '3';
+    }
+  }
+
+  function openCropModal(dataUrl) {
+    if (!dom.cropModal || !dom.cropImage || !dom.cropStage) {
+      return;
+    }
+    resetCropState();
+    const img = new Image();
+    img.onload = () => {
+      cropState.img = img;
+      cropState.scale = 1;
+      cropState.translateX = 0;
+      cropState.translateY = 0;
+      dom.cropImage.src = dataUrl;
+      requestAnimationFrame(() => {
+        updateCropTransform({ updateSlider: true });
+      });
+    };
+    img.onerror = () => {
+      alert('无法加载图片，请尝试其他文件。');
+      closeCropModal();
+    };
+    img.src = dataUrl;
+    dom.cropModal.classList.add('open');
+    dom.cropModal.setAttribute('aria-hidden', 'false');
+    const focusTarget = dom.cropCancelBtn || dom.cropConfirmBtn || dom.cropModal;
+    if (focusTarget && typeof focusTarget.focus === 'function') {
+      focusTarget.focus();
+    }
+  }
+
+  function closeCropModal() {
+    if (!dom.cropModal) return;
+    if (cropState.pointerId && dom.cropStage) {
+      try {
+        dom.cropStage.releasePointerCapture(cropState.pointerId);
+      } catch (err) {
+        // ignore
+      }
+    }
+    dom.cropModal.classList.remove('open');
+    dom.cropModal.setAttribute('aria-hidden', 'true');
+    resetCropState();
+    dom.themeFileInput.value = '';
+    if (dom.themeToggle) {
+      dom.themeToggle.focus();
+    }
+  }
+
+  function updateCropTransform({ updateSlider = false } = {}) {
+    if (!dom.cropStage || !dom.cropImage || !cropState.img) return;
+    const rect = dom.cropStage.getBoundingClientRect();
+    if (!rect.width || !rect.height) return;
+    const minScale = Math.max(rect.width / cropState.img.naturalWidth, rect.height / cropState.img.naturalHeight);
+    cropState.minScale = minScale;
+    cropState.maxScale = Math.max(minScale * 3, minScale + 0.5);
+    cropState.scale = clamp(cropState.scale, cropState.minScale, cropState.maxScale);
+    const scaledWidth = cropState.img.naturalWidth * cropState.scale;
+    const scaledHeight = cropState.img.naturalHeight * cropState.scale;
+    const maxOffsetX = Math.max(0, (scaledWidth - rect.width) / 2);
+    const maxOffsetY = Math.max(0, (scaledHeight - rect.height) / 2);
+    cropState.translateX = clamp(cropState.translateX, -maxOffsetX, maxOffsetX);
+    cropState.translateY = clamp(cropState.translateY, -maxOffsetY, maxOffsetY);
+    dom.cropImage.style.transform = `translate(calc(-50% + ${cropState.translateX}px), calc(-50% + ${cropState.translateY}px)) scale(${cropState.scale})`;
+    if (updateSlider && dom.cropZoom) {
+      dom.cropZoom.min = cropState.minScale.toFixed(2);
+      dom.cropZoom.max = cropState.maxScale.toFixed(2);
+      dom.cropZoom.value = String(cropState.scale);
+    }
+  }
+
+  function handleCropZoomChange(event) {
+    if (!cropState.img) return;
+    const next = parseFloat(event.target.value);
+    if (Number.isNaN(next)) return;
+    cropState.scale = clamp(next, cropState.minScale, cropState.maxScale);
+    updateCropTransform({ updateSlider: true });
+  }
+
+  function handleCropPointerDown(event) {
+    if (!cropState.img || !dom.cropStage) return;
+    event.preventDefault();
+    cropState.pointerId = event.pointerId;
+    cropState.startX = event.clientX;
+    cropState.startY = event.clientY;
+    cropState.startTranslateX = cropState.translateX;
+    cropState.startTranslateY = cropState.translateY;
+    dom.cropStage.setPointerCapture(event.pointerId);
+  }
+
+  function handleCropPointerMove(event) {
+    if (!cropState.img || cropState.pointerId !== event.pointerId) return;
+    event.preventDefault();
+    const dx = event.clientX - cropState.startX;
+    const dy = event.clientY - cropState.startY;
+    cropState.translateX = cropState.startTranslateX + dx;
+    cropState.translateY = cropState.startTranslateY + dy;
+    updateCropTransform();
+  }
+
+  function handleCropPointerUp(event) {
+    if (cropState.pointerId !== event.pointerId) return;
+    cropState.pointerId = null;
+    if (dom.cropStage) {
+      try {
+        dom.cropStage.releasePointerCapture(event.pointerId);
+      } catch (err) {
+        // ignore
+      }
+    }
+  }
+
+  function handleCropConfirm() {
+    if (!cropState.img || !dom.cropStage) {
+      closeCropModal();
+      return;
+    }
+    const rect = dom.cropStage.getBoundingClientRect();
+    if (!rect.width || !rect.height) {
+      closeCropModal();
+      return;
+    }
+    const canvas = document.createElement('canvas');
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.max(1, Math.round(rect.width * dpr));
+    canvas.height = Math.max(1, Math.round(rect.height * dpr));
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      alert('当前环境不支持绘制图片。');
+      closeCropModal();
+      return;
+    }
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.save();
+    ctx.scale(dpr, dpr);
+    ctx.translate(rect.width / 2, rect.height / 2);
+    ctx.translate(cropState.translateX, cropState.translateY);
+    ctx.scale(cropState.scale, cropState.scale);
+    ctx.drawImage(cropState.img, -cropState.img.naturalWidth / 2, -cropState.img.naturalHeight / 2);
+    ctx.restore();
+    const dataUrl = canvas.toDataURL('image/png');
+    mutate((draft) => {
+      draft.prefs.bgImageDataUrl = dataUrl;
+      draft.prefs.theme = 'image';
+    });
+    closeCropModal();
+  }
+
+  function handleImportFileChange(event) {
+    const file = event.target.files && event.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      importFromText(reader.result);
+      dom.importFileInput.value = '';
+    };
+    reader.readAsText(file, 'utf-8');
+  }
+
+  function setupEvents() {
+    const syncToggleSwitch = () => {
+      if (dom.toggleControl) {
+        dom.toggleControl.setAttribute('aria-checked', dom.addToLongterm.checked ? 'true' : 'false');
+      }
+    };
+
+    if (dom.toggleControl) {
+      dom.toggleControl.addEventListener('keydown', (event) => {
+        if (event.key === ' ' || event.key === 'Enter') {
+          event.preventDefault();
+          dom.addToLongterm.checked = !dom.addToLongterm.checked;
+          syncToggleSwitch();
+        }
+      });
+      dom.addToLongterm.addEventListener('change', syncToggleSwitch);
+      syncToggleSwitch();
+    }
+
+    dom.newTodoForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      addTodo(dom.newTodoInput.value, dom.addToLongterm.checked);
+      dom.newTodoInput.value = '';
+      dom.addToLongterm.checked = false;
+      syncToggleSwitch();
+      dom.newTodoInput.focus();
+    });
+
+    dom.filterButtons.forEach((btn) => {
+      btn.addEventListener('click', () => {
+        updateFilter(btn.dataset.filter);
+      });
+    });
+
+    dom.undoBtn.addEventListener('click', handleUndo);
+    if (dom.clearTrashBtn) {
+      dom.clearTrashBtn.addEventListener('click', handleClearTrash);
+    }
+    dom.exportBtn.addEventListener('click', exportData);
+    dom.importBtn.addEventListener('click', handleImport);
+    dom.themeToggle.addEventListener('click', handleThemeToggle);
+    dom.themeFileInput.addEventListener('change', handleThemeFileChange);
+    dom.importFileInput.addEventListener('change', handleImportFileChange);
+
+    if (dom.trashBtn) {
+      dom.trashBtn.addEventListener('click', openTrashPanel);
+    }
+    if (dom.trashCloseBtn) {
+      dom.trashCloseBtn.addEventListener('click', closeTrashPanel);
+    }
+    if (dom.trashPanel) {
+      dom.trashPanel.addEventListener('click', (event) => {
+        if (event.target === dom.trashPanel) {
+          closeTrashPanel();
+        }
+      });
+    }
+
+    if (dom.cropCancelBtn) {
+      dom.cropCancelBtn.addEventListener('click', (event) => {
+        event.preventDefault();
+        closeCropModal();
+      });
+    }
+    if (dom.cropConfirmBtn) {
+      dom.cropConfirmBtn.addEventListener('click', (event) => {
+        event.preventDefault();
+        handleCropConfirm();
+      });
+    }
+    if (dom.cropZoom) {
+      dom.cropZoom.addEventListener('input', handleCropZoomChange);
+    }
+    if (dom.cropStage) {
+      dom.cropStage.addEventListener('pointerdown', handleCropPointerDown);
+      dom.cropStage.addEventListener('pointermove', handleCropPointerMove);
+      dom.cropStage.addEventListener('pointerup', handleCropPointerUp);
+      dom.cropStage.addEventListener('pointercancel', handleCropPointerUp);
+      dom.cropStage.addEventListener('lostpointercapture', handleCropPointerUp);
+    }
+    if (dom.cropModal) {
+      dom.cropModal.addEventListener('click', (event) => {
+        if (event.target === dom.cropModal) {
+          closeCropModal();
+        }
+      });
+    }
+
+    dom.searchInput.addEventListener('input', (event) => {
+      updateSearch(event.target.value);
+    });
+
+    window.addEventListener('resize', () => {
+      if (isCropModalOpen()) {
+        updateCropTransform({ updateSlider: true });
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        if (isCropModalOpen()) {
+          event.preventDefault();
+          closeCropModal();
+          return;
+        }
+        if (isTrashPanelOpen()) {
+          event.preventDefault();
+          closeTrashPanel();
+          return;
+        }
+      }
+
+      if (isCropModalOpen()) {
+        return;
+      }
+
+      if (isTrashPanelOpen()) {
+        return;
+      }
+
+      if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
+        return;
+      }
+
+      if (event.key === 'n' || event.key === 'N') {
+        event.preventDefault();
+        dom.newTodoInput.focus();
+      } else if (event.key === '/') {
+        event.preventDefault();
+        dom.searchInput.focus();
+      } else if (event.key === 'Delete') {
+        const active = document.activeElement;
+        const itemEl = active && active.closest && active.closest('.todo-item');
+        if (itemEl) {
+          const id = itemEl.dataset.id;
+          const section = itemEl.dataset.section;
+          if (section !== 'trash') {
+            handleDelete(id);
+          }
+        }
+      } else if (event.key === 'z' && (event.ctrlKey || event.metaKey)) {
+        event.preventDefault();
+        handleUndo();
+      }
+    });
+
+    dom.searchInput.addEventListener('focus', () => {
+      dom.searchInput.select();
+    });
+  }
+
+  resetLongtermDailyIfNeeded();
+  setupEvents();
+  render();
+})();

--- a/todo-app/assets/icon-add.svg
+++ b/todo-app/assets/icon-add.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10" stroke="white" fill="rgba(255,255,255,0.1)" />
+  <line x1="12" y1="7" x2="12" y2="17" />
+  <line x1="7" y1="12" x2="17" y2="12" />
+</svg>

--- a/todo-app/assets/icon-restore.svg
+++ b/todo-app/assets/icon-restore.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 4v6h6" />
+  <path d="M20 11c-1-5-5.5-8-10-7-3.6.8-6.3 4-6 7.7.4 3.8 3.7 6.8 7.5 6.8 2.7 0 5.1-1.4 6.5-3.5" />
+</svg>

--- a/todo-app/assets/icon-trash.svg
+++ b/todo-app/assets/icon-trash.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="3 6 5 6 21 6" />
+  <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+  <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+  <line x1="10" y1="11" x2="10" y2="17" />
+  <line x1="14" y1="11" x2="14" y2="17" />
+</svg>

--- a/todo-app/assets/icon-upload.svg
+++ b/todo-app/assets/icon-upload.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+  <polyline points="7 10 12 5 17 10" />
+  <line x1="12" y1="5" x2="12" y2="19" />
+</svg>

--- a/todo-app/index.html
+++ b/todo-app/index.html
@@ -1,0 +1,171 @@
+<!-- 使用说明 & 快捷键：N 新建；/ 搜索；Delete 删除；Ctrl+Z 撤销；双击条目可编辑；Enter 保存编辑；Esc 取消编辑。 -->
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>离线待办清单</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="app-header" role="banner">
+    <div class="branding" tabindex="0">
+      <h1>记得干活！！</h1>
+      <span class="tagline">规划 · 打卡 · 管理</span>
+    </div>
+    <div class="search-area" role="search">
+      <label class="sr-only" for="searchInput">搜索待办</label>
+      <input id="searchInput" type="search" placeholder="搜索所有待办 /" aria-label="搜索待办" />
+    </div>
+    <div class="header-actions" role="group" aria-label="快速操作">
+      <button id="undoBtn" class="ghost" aria-label="撤销上一次删除" title="撤销上一次删除 (Ctrl+Z)" disabled>
+        撤销
+      </button>
+      <div class="filter-group" role="radiogroup" aria-label="筛选视图">
+        <button class="filter-btn active" data-filter="all" role="radio" aria-checked="true">全部</button>
+        <button class="filter-btn" data-filter="inProgress" role="radio" aria-checked="false">进行中</button>
+        <button class="filter-btn" data-filter="done" role="radio" aria-checked="false">已完成</button>
+        <button class="filter-btn" data-filter="longterm" role="radio" aria-checked="false">长期</button>
+      </div>
+      <button id="themeToggle" class="ghost" aria-label="背景切换" title="背景切换">
+        背景切换
+      </button>
+      <button id="trashBtn" class="icon-pill" aria-label="打开垃圾桶" title="垃圾桶">
+        <img src="assets/icon-trash.svg" alt="" aria-hidden="true" />
+        <span class="badge" id="trashCount">0</span>
+      </button>
+      <button id="exportBtn" class="ghost" aria-label="导出待办 JSON" title="导出 JSON">
+        导出
+      </button>
+      <button id="importBtn" class="ghost" aria-label="导入待办 JSON" title="导入 JSON">
+        导入
+      </button>
+      <input id="themeFileInput" type="file" accept="image/*" hidden />
+      <input id="importFileInput" type="file" accept="application/json" hidden />
+    </div>
+  </header>
+
+  <main class="app-main" role="main">
+    <section class="new-todo-bar" aria-label="新增待办">
+      <form id="newTodoForm">
+        <label class="sr-only" for="newTodoInput">新增待办</label>
+        <input id="newTodoInput" type="text" placeholder="输入待办事项..." aria-label="待办内容" required />
+        <div class="new-todo-actions">
+          <label class="toggle" tabindex="0" role="switch" aria-checked="false">
+            <input type="checkbox" id="addToLongterm" />
+            <span class="slider" aria-hidden="true"></span>
+            <span class="toggle-label">加入长期栏</span>
+          </label>
+          <button type="submit" class="primary" aria-label="添加待办">
+            <img src="assets/icon-add.svg" alt="" aria-hidden="true" />
+            添加
+          </button>
+        </div>
+      </form>
+    </section>
+
+    <div class="board" role="region" aria-label="待办面板">
+      <section class="column" data-section="inProgress" aria-labelledby="inProgressTitle">
+        <header class="column-header">
+          <h2 id="inProgressTitle">进行中</h2>
+          <span class="badge" id="inProgressCount">0</span>
+        </header>
+        <div class="empty-state" data-section="inProgress">🎯 今天的目标是什么？开始添加吧。</div>
+        <ul class="todo-list" id="inProgressList" aria-label="进行中待办列表"></ul>
+      </section>
+
+      <section class="column" data-section="done" aria-labelledby="doneTitle">
+        <header class="column-header">
+          <h2 id="doneTitle">已完成</h2>
+          <span class="badge" id="doneCount">0</span>
+        </header>
+        <div class="empty-state" data-section="done">✨ 完成会带来满足感，加油！</div>
+        <ul class="todo-list" id="doneList" aria-label="已完成待办列表"></ul>
+      </section>
+
+      <section class="column" data-section="longterm" aria-labelledby="longtermTitle">
+        <header class="column-header">
+          <h2 id="longtermTitle">长期</h2>
+          <span class="badge" id="longtermCount">0</span>
+        </header>
+        <div class="empty-state" data-section="longterm">🌱 积少成多，让习惯开花。</div>
+        <ul class="todo-list" id="longtermList" aria-label="长期待办列表"></ul>
+      </section>
+    </div>
+  </main>
+
+  <div id="trashPanel" class="trash-panel" role="dialog" aria-modal="true" aria-hidden="true" aria-labelledby="trashPanelTitle" tabindex="-1">
+    <div class="trash-content">
+      <header class="trash-header">
+        <h2 id="trashPanelTitle">垃圾桶</h2>
+        <button id="trashCloseBtn" class="ghost" aria-label="关闭垃圾桶" title="关闭">×</button>
+      </header>
+      <div class="trash-body">
+        <div class="empty-state" data-section="trash">🗑️ 垃圾桶是空的。</div>
+        <ul class="trash-list" id="trashList" aria-label="垃圾桶列表"></ul>
+      </div>
+      <footer class="trash-footer">
+        <button id="clearTrashBtn" class="ghost" aria-label="清空垃圾桶" title="清空垃圾桶">清空垃圾桶</button>
+      </footer>
+    </div>
+  </div>
+
+  <div id="cropModal" class="crop-modal" role="dialog" aria-modal="true" aria-hidden="true" aria-labelledby="cropModalTitle" tabindex="-1">
+    <div class="crop-content">
+      <header class="crop-header">
+        <h2 id="cropModalTitle">调整自定义背景</h2>
+        <p>拖动图片定位，使用滑块缩放。</p>
+      </header>
+      <div class="crop-stage-wrapper">
+        <div class="crop-stage" id="cropStage">
+          <img id="cropImage" alt="裁剪预览" />
+          <div class="crop-mask" aria-hidden="true"></div>
+        </div>
+      </div>
+      <label class="crop-zoom-label" for="cropZoom">缩放</label>
+      <input type="range" id="cropZoom" min="1" max="3" step="0.01" value="1" aria-label="背景缩放" />
+      <div class="crop-actions">
+        <button id="cropCancelBtn" class="ghost">取消</button>
+        <button id="cropConfirmBtn" class="primary">应用</button>
+      </div>
+    </div>
+  </div>
+
+  <template id="todoItemTemplate">
+    <li class="todo-item" tabindex="0">
+      <label class="checkbox" aria-label="标记状态">
+        <input type="checkbox" />
+        <span class="checkmark" aria-hidden="true"></span>
+      </label>
+      <div class="item-body">
+        <div class="item-content" role="textbox" aria-readonly="true"></div>
+        <span class="longterm-status" aria-hidden="true"></span>
+      </div>
+      <button class="delete-btn ghost" aria-label="删除" title="删除">×</button>
+    </li>
+  </template>
+
+  <template id="trashItemTemplate">
+    <li class="trash-item" tabindex="0">
+      <div class="trash-info">
+        <p class="trash-text"></p>
+        <p class="trash-meta"></p>
+      </div>
+      <div class="trash-actions">
+        <button class="restore-btn ghost" aria-label="还原" title="还原">
+          <img src="assets/icon-restore.svg" alt="" aria-hidden="true" />
+          还原
+        </button>
+        <button class="delete-btn ghost" aria-label="彻底删除" title="彻底删除">
+          <img src="assets/icon-trash.svg" alt="" aria-hidden="true" />
+          删除
+        </button>
+      </div>
+    </li>
+  </template>
+
+  <textarea id="importTextarea" class="modal-textarea" aria-label="导入 JSON 输入框" hidden></textarea>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/todo-app/styles.css
+++ b/todo-app/styles.css
@@ -1,0 +1,776 @@
+:root {
+  --bg-gradient: radial-gradient(circle at top left, #1f2a44, #0b0d1a 60%);
+  --card-bg: rgba(21, 26, 41, 0.55);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text-color: #f6f8ff;
+  --muted-color: rgba(246, 248, 255, 0.72);
+  --accent: #6c8cff;
+  --accent-soft: rgba(108, 140, 255, 0.14);
+  --danger: #ff6b81;
+  --success: #5ad1a4;
+  --focus-ring: 0 0 0 3px rgba(108, 140, 255, 0.45);
+  --shadow: 0 18px 35px rgba(7, 10, 20, 0.35);
+  --transition: 0.2s ease;
+  --glass-blur: blur(18px);
+  --column-gap: clamp(1.2rem, 3vw, 2rem);
+  --max-width: min(1220px, 92vw);
+  --item-bg: rgba(255, 248, 235, 0.92);
+  --item-border: rgba(86, 68, 44, 0.25);
+  --item-text: #3b2f1f;
+  --item-muted: rgba(59, 47, 31, 0.6);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  font-family: "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+  background: var(--bg-gradient);
+  color: var(--text-color);
+  min-height: 100vh;
+}
+
+body {
+  position: relative;
+  overflow-x: hidden;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: var(--bg-gradient);
+  background-size: cover;
+  background-position: center;
+  opacity: 0.45;
+  z-index: -2;
+  transition: opacity var(--transition);
+}
+
+body[data-theme="image"]::before {
+  background: var(--custom-bg, var(--bg-gradient));
+  background-size: cover;
+  background-position: center;
+  opacity: 1;
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  backdrop-filter: var(--glass-blur);
+  z-index: -1;
+}
+
+main, header, section, ul {
+  width: 100%;
+}
+
+.app-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  margin: 0 auto;
+  width: var(--max-width);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 20px;
+  box-shadow: var(--shadow);
+  position: sticky;
+  top: 0.75rem;
+  z-index: 10;
+}
+
+.branding {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.branding h1 {
+  font-size: clamp(1.4rem, 2vw, 1.9rem);
+  margin: 0;
+}
+
+.tagline {
+  font-size: 0.85rem;
+  color: var(--muted-color);
+}
+
+.search-area input,
+.modal-textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-color);
+  font-size: 0.95rem;
+  transition: border var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.search-area input::placeholder {
+  color: rgba(246, 248, 255, 0.5);
+}
+
+.search-area input:focus,
+.modal-textarea:focus {
+  outline: none;
+  border-color: rgba(108, 140, 255, 0.45);
+  box-shadow: var(--focus-ring);
+}
+
+#newTodoInput {
+  flex: 1 1 320px;
+  min-height: 3rem;
+  font-size: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(59, 47, 31, 0.25);
+  background: rgba(255, 255, 255, 0.85);
+  color: var(--item-text);
+  transition: box-shadow var(--transition), border-color var(--transition);
+}
+
+#newTodoInput::placeholder {
+  color: rgba(59, 47, 31, 0.45);
+}
+
+#newTodoInput:focus {
+  outline: none;
+  border-color: rgba(108, 140, 255, 0.4);
+  box-shadow: 0 0 0 3px rgba(108, 140, 255, 0.25);
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.filter-group {
+  display: flex;
+  gap: 0.35rem;
+  background: rgba(255, 255, 255, 0.04);
+  padding: 0.35rem;
+  border-radius: 14px;
+}
+
+button {
+  border: none;
+  padding: 0.55rem 0.95rem;
+  border-radius: 12px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-color);
+  background: var(--accent-soft);
+  transition: transform var(--transition), background var(--transition), color var(--transition), box-shadow var(--transition);
+}
+
+button:focus-visible,
+.todo-item:focus-visible,
+.toggle:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+button:hover {
+  transform: translateY(-1px);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+button img {
+  width: 1rem;
+  height: 1rem;
+  margin-right: 0.35rem;
+  filter: invert(1);
+}
+
+button.ghost {
+  color: var(--muted-color);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+button.primary {
+  background: linear-gradient(135deg, #6c8cff, #4a68ff);
+  box-shadow: 0 12px 24px rgba(76, 104, 255, 0.35);
+}
+
+.icon-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding-inline: 0.85rem;
+}
+
+.icon-pill img {
+  margin: 0;
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.icon-pill .badge {
+  background: rgba(108, 140, 255, 0.25);
+  padding: 0.15rem 0.55rem;
+}
+
+.icon-pill.highlight {
+  background: rgba(108, 140, 255, 0.22);
+}
+
+.filter-btn {
+  padding: 0.4rem 0.85rem;
+  border-radius: 10px;
+  background: transparent;
+  font-weight: 500;
+  color: var(--muted-color);
+}
+
+.filter-btn.active {
+  background: rgba(108, 140, 255, 0.2);
+  color: var(--text-color);
+}
+
+.app-main {
+  margin: 1.25rem auto 3rem;
+  width: var(--max-width);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.new-todo-bar {
+  padding: 0;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+}
+
+.new-todo-bar form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  align-items: center;
+  background: var(--item-bg);
+  border: 1px solid var(--item-border);
+  border-radius: 20px;
+  padding: 0.9rem 1.1rem;
+  box-shadow: 0 18px 36px rgba(31, 24, 16, 0.22);
+}
+
+.new-todo-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.board {
+  display: grid;
+  gap: var(--column-gap);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.column {
+  transition: max-height var(--transition), opacity var(--transition);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 20px;
+  padding: 1.1rem 1.25rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  box-shadow: var(--shadow);
+  min-height: 220px;
+}
+
+.column-header {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.column-header h2 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.badge {
+  background: rgba(108, 140, 255, 0.22);
+  color: var(--text-color);
+  border-radius: 999px;
+  padding: 0.15rem 0.6rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.02em;
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.toggle input {
+  display: none;
+}
+
+.toggle .slider {
+  width: 42px;
+  height: 24px;
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 999px;
+  position: relative;
+  transition: background var(--transition);
+}
+
+.toggle .slider::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 4px;
+  width: 18px;
+  height: 18px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform var(--transition);
+}
+
+.toggle input:checked + .slider {
+  background: rgba(90, 209, 164, 0.3);
+}
+
+.toggle input:checked + .slider::after {
+  transform: translateX(16px);
+}
+
+.toggle-label {
+  font-size: 0.85rem;
+  color: var(--muted-color);
+}
+
+.new-todo-actions .toggle .slider {
+  background: rgba(59, 47, 31, 0.2);
+}
+
+.new-todo-actions .toggle input:checked + .slider {
+  background: rgba(39, 137, 98, 0.35);
+}
+
+.new-todo-actions .toggle-label {
+  color: var(--item-muted);
+}
+
+.todo-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.todo-item {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.85rem 1rem;
+  border-radius: 18px;
+  background: var(--item-bg);
+  border: 1px solid var(--item-border);
+  transition: transform var(--transition), box-shadow var(--transition);
+  color: var(--item-text);
+}
+
+.todo-item:hover,
+.todo-item:focus-within,
+.todo-item:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 26px rgba(31, 24, 16, 0.18);
+}
+
+.checkbox {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.65);
+  position: relative;
+  border: 1px solid rgba(59, 47, 31, 0.2);
+}
+
+.checkbox input {
+  position: absolute;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  cursor: pointer;
+}
+
+.checkmark {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  border: 2px solid rgba(78, 62, 40, 0.3);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.checkbox input:checked + .checkmark {
+  background: linear-gradient(135deg, #6c8cff, #4a68ff);
+  border-color: transparent;
+}
+
+.item-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  flex: 1;
+}
+
+.item-content {
+  flex: 1;
+  min-height: 1.3rem;
+  line-height: 1.4;
+  word-break: break-word;
+  font-size: 0.98rem;
+}
+
+.todo-item.done .item-content {
+  text-decoration: line-through;
+  color: rgba(59, 47, 31, 0.4);
+}
+
+.todo-item.longterm.done-today .item-content {
+  text-decoration: none;
+  color: var(--item-text);
+}
+
+
+.todo-item .delete-btn {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 50%;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(59, 47, 31, 0.1);
+  color: rgba(59, 47, 31, 0.75);
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.todo-item .delete-btn:hover {
+  background: rgba(59, 47, 31, 0.18);
+}
+
+.todo-item .delete-btn img {
+  display: none;
+}
+
+.todo-item .edit-input {
+  flex: 1;
+  padding: 0.6rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(59, 47, 31, 0.3);
+  background: rgba(255, 255, 255, 0.85);
+  font-size: 0.95rem;
+  color: #2e2518;
+}
+
+.todo-item.editing .item-content {
+  display: none;
+}
+
+.item-body .longterm-status {
+  font-size: 0.75rem;
+  color: var(--item-muted);
+  background: rgba(60, 214, 153, 0.18);
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  display: none;
+  align-self: flex-start;
+}
+
+.todo-item.longterm.done-today .longterm-status {
+  display: inline-flex;
+  color: #278962;
+  font-weight: 600;
+}
+
+.empty-state {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 16px;
+  padding: 1.1rem;
+  text-align: center;
+  color: rgba(246, 248, 255, 0.6);
+  font-size: 0.9rem;
+  display: none;
+}
+
+.column.show-empty .empty-state {
+  display: block;
+}
+
+.modal-textarea {
+  min-height: 220px;
+  border-radius: 18px;
+  background: rgba(16, 20, 35, 0.9);
+  color: var(--text-color);
+  padding: 1.2rem;
+  resize: vertical;
+}
+
+.trash-panel,
+.crop-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(5, 7, 14, 0.72);
+  backdrop-filter: blur(10px);
+  z-index: 40;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition);
+}
+
+.trash-panel.open,
+.crop-modal.open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.trash-content,
+.crop-content {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 20px;
+  box-shadow: var(--shadow);
+  padding: 1.2rem 1.4rem;
+  width: min(600px, 90vw);
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.trash-header,
+.crop-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.trash-header h2,
+.crop-header h2 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.trash-body {
+  flex: 1;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.trash-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.trash-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.trash-item:hover,
+.trash-item:focus-visible {
+  outline: none;
+  background: rgba(255, 255, 255, 0.1);
+  box-shadow: 0 12px 24px rgba(7, 10, 20, 0.25);
+}
+
+.trash-text {
+  margin: 0 0 0.2rem;
+  font-size: 0.95rem;
+}
+
+.trash-meta {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(246, 248, 255, 0.6);
+}
+
+.trash-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.trash-footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.crop-content {
+  width: min(720px, 92vw);
+  max-height: 90vh;
+}
+
+.crop-header p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted-color);
+}
+
+.crop-stage-wrapper {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.crop-stage {
+  position: relative;
+  width: min(640px, 100%);
+  height: clamp(240px, 55vh, 380px);
+  border-radius: 20px;
+  overflow: hidden;
+  background: rgba(7, 10, 20, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  cursor: grab;
+  touch-action: none;
+}
+
+.crop-stage:active {
+  cursor: grabbing;
+}
+
+#cropImage {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  transform-origin: center;
+  user-select: none;
+  -webkit-user-drag: none;
+}
+
+.crop-mask {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.18);
+}
+
+.crop-zoom-label {
+  font-size: 0.85rem;
+  color: var(--muted-color);
+}
+
+#cropZoom {
+  width: 100%;
+}
+
+.crop-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.crop-modal .ghost {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.crop-modal .primary {
+  min-width: 120px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 1024px) {
+  .board {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 768px) {
+  .app-header {
+    position: static;
+  }
+
+  .board {
+    grid-template-columns: 1fr;
+  }
+
+  .new-todo-bar form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .new-todo-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .todo-item {
+    align-items: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    transition-duration: 0s !important;
+    animation-duration: 0s !important;
+  }
+}
+
+.column.hidden {
+  display: none;
+}
+
+button.danger, button.ghost.danger {
+  background: rgba(255, 107, 129, 0.18);
+  color: #ffced7;
+}


### PR DESCRIPTION
## Summary
- move the add form above the board, keep the workspace to three wider columns, and update the header text and item structure to match the desired horizontal layout
- replace the trash column with an icon-triggered dialog and adjust styling/logic to manage trash entries and long-term badges inline
- add an interactive background image cropper that supports zoom/drag before persisting custom themes

## Testing
- node -e "new Function(require('fs').readFileSync('todo-app/app.js','utf8'))"

------
https://chatgpt.com/codex/tasks/task_e_68e68a8ec9988322b718fd2db8da2b48